### PR TITLE
Remove duplicated atof function declaration

### DIFF
--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2748,7 +2748,6 @@ extern "C" {
     pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn abs(i: ::c_int) -> ::c_int;
-    pub fn atof(s: *const ::c_char) -> ::c_double;
     pub fn labs(i: ::c_long) -> ::c_long;
     pub fn rand() -> ::c_int;
     pub fn srand(seed: ::c_uint);


### PR DESCRIPTION
This adapts to the changes done with PR #3036